### PR TITLE
fix: Ranaming projects was a problem, removed Lookup service provider…

### DIFF
--- a/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/NodeJSExecutorImpl.java
+++ b/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/NodeJSExecutorImpl.java
@@ -22,10 +22,7 @@ import java.util.concurrent.atomic.*;
 /**
  * @author w.glanzer, 08.03.2021
  */
-@ServiceProviders({
-    @ServiceProvider(service = INodeJSExecutor.class, path = "Projects/de-adito-project/Lookup"), //backwards compatibility to 2022.0.0
-    @ServiceProvider(service = INodeJSExecutor.class, path = "Projects/de-adito-project/StaticLookup"),
-})
+@ServiceProvider(service = INodeJSExecutor.class, path = "Projects/de-adito-project/StaticLookup")
 public class NodeJSExecutorImpl implements INodeJSExecutor
 {
   private static final String _PATH_ENVIRONMENT = "PATH";

--- a/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/NodeJSProviderImpl.java
+++ b/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/NodeJSProviderImpl.java
@@ -16,10 +16,7 @@ import java.util.Optional;
 /**
  * @author w.glanzer, 05.03.2021
  */
-@ServiceProviders({
-    @ServiceProvider(service = INodeJSProvider.class, path = "Projects/de-adito-project/Lookup"), //backwards compatibility to 2022.0.0
-    @ServiceProvider(service = INodeJSProvider.class, path = "Projects/de-adito-project/StaticLookup"),
-})
+@ServiceProvider(service = INodeJSProvider.class, path = "Projects/de-adito-project/StaticLookup")
 public class NodeJSProviderImpl implements INodeJSProvider
 {
   private final Project project;

--- a/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/runconfig/NodeJSScriptsRunConfigProvider.java
+++ b/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/runconfig/NodeJSScriptsRunConfigProvider.java
@@ -7,6 +7,7 @@ import de.adito.observables.netbeans.*;
 import io.reactivex.rxjava3.core.Observable;
 import org.jetbrains.annotations.NotNull;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ui.OpenProjects;
 import org.openide.util.lookup.ServiceProvider;
 
 import java.io.File;
@@ -37,7 +38,7 @@ public class NodeJSScriptsRunConfigProvider implements ISystemRunConfigProvider
   @Override
   public Observable<List<IRunConfig>> runConfigurations(List<ISystemInfo> pList)
   {
-    if (project == null)
+    if (project == null || !Arrays.stream(OpenProjects.getDefault().getOpenProjects()).filter(p -> p.equals(project)).findFirst().isPresent())
       return Observable.just(List.of());
     return _createRunConfigsForProject(project);
   }


### PR DESCRIPTION
…, because backwars compatibility was no longer given in project. Added a condition to check if the project in NodeJSScriptsRunConfigProvider is in the opened projects before creating the run configurations of the project.