### PR TITLE
fix #2015192: PackageParser can read package.json files again.

### DIFF
--- a/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/parser/PackageParser.java
+++ b/src/main/java/de/adito/aditoweb/nbm/nodejs/impl/parser/PackageParser.java
@@ -2,16 +2,21 @@ package de.adito.aditoweb.nbm.nodejs.impl.parser;
 
 import com.google.gson.Gson;
 import de.adito.aditoweb.nbm.nbide.nbaditointerface.javascript.node.INodeJSExecBase;
+import lombok.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
 import java.util.*;
+import java.util.logging.*;
 
 /**
  * @author w.glanzer, 12.05.2021
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PackageParser
 {
+  private static final Logger logger = Logger.getLogger(PackageParser.class.getName());
+
   /**
    * Parses the package.json and extracts all set scripts.
    * Key: ScriptName, Value: Script
@@ -28,7 +33,8 @@ public class PackageParser
     }
     catch (Exception e)
     {
-      // just return empty map
+      // just return empty map, but log the exception
+      logger.log(Level.WARNING, e.getMessage(), e);
     }
 
     return Map.of();
@@ -52,17 +58,18 @@ public class PackageParser
     }
     catch (Exception e)
     {
-      // just return empty map
+      // just return empty map, but log the exception
+      logger.log(Level.WARNING, e.getMessage(), e);
     }
 
     return Map.of();
   }
 
   /**
-   * Parses the output of "npm list" and returns the binaries,
+   * Parses the output of "npm list -j -l" and returns the binaries,
    * so that we don't have to use the ".cmd" wrapper.
    *
-   * @param pJsonData output of "npm list"
+   * @param pJsonData output of "npm list -j -l"
    * @return a map of binaries and their INodeJSExecBase, pointing to the resolved javascript file
    */
   @NotNull
@@ -70,11 +77,11 @@ public class PackageParser
   {
     try
     {
-      _Type root = new Gson().fromJson(pJsonData, _Type.class);
+      NpmListType root = new Gson().fromJson(pJsonData, NpmListType.class);
       if (root.dependencies != null)
       {
         Map<String, INodeJSExecBase> res = new HashMap<>();
-        for (Map.Entry<String, _Type> dep : root.dependencies.entrySet())
+        for (Map.Entry<String, NpmListType> dep : root.dependencies.entrySet())
         {
           if (dep.getValue().bin == null)
             continue;
@@ -86,7 +93,8 @@ public class PackageParser
     }
     catch (Exception pE)
     {
-      // just return empty map
+      // just return empty map, but log the exception
+      logger.log(Level.WARNING, pE.getMessage(), pE);
     }
 
     return Map.of();
@@ -97,8 +105,15 @@ public class PackageParser
    */
   private static class _Type
   {
-    public Map<String, _Type> dependencies;
     public Map<String, String> scripts;
+  }
+
+  /**
+   * gson type of the result of {@code npm list -j -l}
+   */
+  private static class NpmListType extends _Type
+  {
+    public Map<String, NpmListType> dependencies;
     public Map<String, String> bin;
   }
 

--- a/src/test/java/de/adito/aditoweb/nbm/nodejs/impl/parser/PackageParserTest.java
+++ b/src/test/java/de/adito/aditoweb/nbm/nodejs/impl/parser/PackageParserTest.java
@@ -1,9 +1,16 @@
 package de.adito.aditoweb.nbm.nodejs.impl.parser;
 
+import com.google.common.collect.Sets;
+import de.adito.aditoweb.nbm.nbide.nbaditointerface.javascript.node.INodeJSExecBase;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
 
-import java.io.StringReader;
-import java.util.Map;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author w.glanzer, 12.05.2021
@@ -38,4 +45,134 @@ class PackageParserTest
     Assertions.assertEquals(Map.of(), PackageParser.parseScripts(new StringReader("{ scripts: {  äö / \"")));
   }
 
+
+  /**
+   * Tests the method {@link PackageParser#parseScripts(File)}.
+   */
+  @Nested
+  class ParseScripts
+  {
+    private final Map.Entry<String, String> resetData = Map.entry("reset:data", "run reset.sh");
+    private final Map.Entry<String, String> publishModule = Map.entry("publishModule", "npm publish");
+    private final Map.Entry<String, String> startMariaDb = Map.entry("startMariaDB", "node ./scripts/mariaDB.js");
+
+
+    /**
+     * Tests the method call with a normal package.json.
+     *
+     * @throws URISyntaxException if the filename cannot be converted to URI
+     */
+    @Test
+    void shouldParseScriptsBasic() throws URISyntaxException
+    {
+      baseParseScripts(Set.of(resetData, startMariaDb), "package_basic.json");
+    }
+
+    /**
+     * Tests the method call with a modularized project package.json.
+     *
+     * @throws URISyntaxException if the filename cannot be converted to URI
+     */
+    @Test
+    void shouldParseScriptsModularizedProject() throws URISyntaxException
+    {
+      baseParseScripts(Set.of(publishModule, resetData), "package_project.json");
+    }
+
+    /**
+     * Tests the method call with a modularized module package.json.
+     *
+     * @throws URISyntaxException if the filename cannot be converted to URI
+     */
+    @Test
+    void shouldParseScriptsModularizedModule() throws URISyntaxException
+    {
+      baseParseScripts(Set.of(publishModule, startMariaDb), "package_module.json");
+
+    }
+
+    /**
+     * Basic method for calling {@link PackageParser#parseScripts(File)}. This method reads the file from the resources folder and passes it as file to the method.
+     *
+     * @param expectedValues the expected map entries that should be returned by the method
+     * @param filename       The name of the file in the resources folder
+     * @throws URISyntaxException If the read url of the filename can not be converted into an {@link URI}
+     */
+    private void baseParseScripts(@NotNull Set<Map.Entry<String, String>> expectedValues, @NotNull String filename) throws URISyntaxException
+    {
+      // builds the expected map out of the set
+      Map<String, String> expected = expectedValues.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      // loads the given .json file and checks that it exists
+      URL url = PackageParserTest.class.getClassLoader().getResource(PackageParserTest.class.getPackageName().replace(".", "/") + "/" + filename);
+      assertNotNull(url);
+
+      // transform the url to file
+      File file = new File(url.toURI());
+
+      Map<String, String> actual = PackageParser.parseScripts(file);
+
+      assertEquals(expected, actual);
+    }
+  }
+
+
+  /**
+   * Tests the method {@link PackageParser#parseBinaries(String)}
+   */
+  @Nested
+  class ParseBinaries
+  {
+    /**
+     * Tests that the binaries are found from an expample json
+     */
+    @Test
+    void shouldParseBinaries()
+    {
+
+      String jsonData = "\n" +
+          "{\n" +
+          "  \"version\": \"1.0.0\",\n" +
+          "  \"name\": \"project\",\n" +
+          "  \"private\": true,\n" +
+          "  \"type\": \"project\",\n" +
+          "  \"scripts\": {\n" +
+          "    \"list\": \"npm list -j -l\"\n" +
+          "  },\n" +
+          "  \"_id\": \"project@1.0.0\",\n" +
+          "  \"extraneous\": false,\n" +
+          "  \"path\": \"C:\\\\dev\\\\projects\\\\modularization\\\\project\",\n" +
+          "  \"_dependencies\": {\n" +
+          "    \"module1\": \"../module1\"\n" +
+          "  },\n" +
+          "  \"devDependencies\": {},\n" +
+          "  \"peerDependencies\": {},\n" +
+          "  \"dependencies\": {\n" +
+          "    \"module1\": {\n" +
+          "      \"version\": \"1.0.0\",\n" +
+          "      \"resolved\": \"file:../../module1\",\n" +
+          "      \"overridden\": false,\n" +
+          "      \"name\": \"module1-1\",\n" +
+          "      \"_id\": \"module1-1@1.0.0\",\n" +
+          "      \"extraneous\": false,\n" +
+          "      \"path\": \"C:\\\\dev\\\\projects\\\\modularization\\\\project\\\\node_modules\\\\module1\",\n" +
+          "      \"_dependencies\": {},\n" +
+          "      \"devDependencies\": {},\n" +
+          "      \"peerDependencies\": {},\n" +
+          "      \"bin\": {\"a\": \"b\", \"c\": \"d\"}\n" +
+          "    }\n" +
+          "  }\n" +
+          "}";
+
+      Map<String, INodeJSExecBase> result = PackageParser.parseBinaries(jsonData);
+
+      assertAll(
+          () -> assertEquals(2, result.size(), "length should be 2"),
+          () -> assertEquals(Sets.newHashSet("a", "c"), result.keySet(), "keys should be a and c"),
+          () -> assertEquals("node_modules/module1/b", result.get("a").getBasePath(), "base path of a"),
+          () -> assertEquals("node_modules/module1/d", result.get("c").getBasePath(), "base path of c"));
+    }
+  }
+
 }
+

--- a/src/test/resources/de/adito/aditoweb/nbm/nodejs/impl/parser/package_basic.json
+++ b/src/test/resources/de/adito/aditoweb/nbm/nodejs/impl/parser/package_basic.json
@@ -1,0 +1,33 @@
+{
+  "name": "basic",
+  "private": true,
+  "dependencies": {
+    "@aditosoftware/jdito-types": "^2022.0.0"
+  },
+  "devDependencies": {
+    "adm-zip": "0.5.9",
+    "compressing": "1.5.1",
+    "cypress": "9.5.0",
+    "cypress-tags": "0.2.0",
+    "cypress-wait-until": "^1.7.1",
+    "mariadb": "2.5.5",
+    "mocha": "^8.3.2",
+    "mochawesome": "^6.2.2",
+    "mochawesome-merge": "^4.2.0",
+    "mochawesome-report-generator": "^5.2.0",
+    "node-liquibase": "4.1.1",
+    "superagent": "6.1.0",
+    "typescript": "^4.3.5",
+    "urllib": "2.38.0",
+    "liquibase": "4.4.0",
+    "eslint": "8.12.0",
+    "@typescript-eslint/parser": "^5.18.0",
+    "@typescript-eslint/eslint-plugin": "^5.18.0",
+    "eslint-plugin-brace-rules": "^0.1.6",
+    "eslint-plugin-standard": "^4.0.2"
+  },
+  "scripts": {
+    "reset:data": "run reset.sh",
+    "startMariaDB": "node ./scripts/mariaDB.js"
+  }
+}

--- a/src/test/resources/de/adito/aditoweb/nbm/nodejs/impl/parser/package_module.json
+++ b/src/test/resources/de/adito/aditoweb/nbm/nodejs/impl/parser/package_module.json
@@ -1,0 +1,10 @@
+{
+  "name": "module2",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "publishModule": "npm publish",
+    "startMariaDB": "node ./scripts/mariaDB.js"
+  }
+}

--- a/src/test/resources/de/adito/aditoweb/nbm/nodejs/impl/parser/package_project.json
+++ b/src/test/resources/de/adito/aditoweb/nbm/nodejs/impl/parser/package_project.json
@@ -1,0 +1,15 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "private": true,
+  "type": "project",
+  "dependencies": {
+    "module1": "../module1",
+    "module1-1": "../module1-1",
+    "module2": "../module2"
+  },
+  "scripts": {
+    "publishModule": "npm publish",
+    "reset:data": "run reset.sh"
+  }
+}


### PR DESCRIPTION
 Splitted _Type and NpmListType, so that the dependencies files is not interferred between package.json (String values, not needed) and npm list (object values, needed)